### PR TITLE
Change DB creation script from .sh to .sql

### DIFF
--- a/storage/postgres/compose.yml
+++ b/storage/postgres/compose.yml
@@ -6,7 +6,8 @@ services:
       - '5432:5432'
     volumes:
       - data:/var/lib/postgresql/data
-      - ./init-database.sh:/docker-entrypoint-initdb.d/init-database.sh
+      # - ./init-database.sh:/docker-entrypoint-initdb.d/init-database.sh
+      - ./init-database.sql:/docker-entrypoint-initdb.d/init-database.sql
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: password

--- a/storage/postgres/init-database.sql
+++ b/storage/postgres/init-database.sql
@@ -1,0 +1,13 @@
+-- create hive admin and database
+CREATE USER hiveadmin;
+ALTER USER hiveadmin PASSWORD 'password';
+
+CREATE DATABASE metastore_db;
+GRANT ALL PRIVILEGES ON DATABASE metastore_db TO hiveadmin;
+
+-- create iceberg admin and database
+CREATE USER icebergadmin;
+ALTER USER icebergadmin PASSWORD 'password';
+
+CREATE DATABASE iceberg;
+GRANT ALL PRIVILEGES ON DATABASE iceberg TO icebergadmin;


### PR DESCRIPTION
Change DB creation script from .sh to .sql to support bind-mounting file on mode-less filesystems